### PR TITLE
ボタンの色を青に変更

### DIFF
--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -12,12 +12,12 @@ export const TodoItem = memo(function TodoItem({ todo, onToggle, onDelete }: Tod
     <div className="group flex items-center gap-2 p-[2px] hover:bg-black/10 rounded transition-all duration-200">
       <button
         onClick={() => onToggle?.(todo.id)}
-        className="flex items-center justify-center w-3.5 h-3.5 border border-black rounded-sm bg-white hover:bg-gray-50 transition-colors"
+        className="flex items-center justify-center w-3.5 h-3.5 border border-blue-500 rounded-sm bg-white hover:bg-blue-50 transition-colors"
         aria-label={`${todo.title}${todo.completed ? 'を未完了にする' : 'を完了済みにする'}`}
       >
         {todo.completed && (
           <svg
-            className="w-3 h-3 text-black"
+            className="w-3 h-3 text-blue-500"
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 24 24"
             fill="none"
@@ -47,7 +47,7 @@ export const TodoItem = memo(function TodoItem({ todo, onToggle, onDelete }: Tod
         aria-label={`${todo.title}を削除`}
       >
         <svg
-          className="w-4 h-4 text-black"
+          className="w-4 h-4 text-red-500 hover:text-red-600"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"
           fill="none"

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -96,7 +96,7 @@ export function TodoList({ todos, onToggle, onDelete, onDeleteAll, onAdd }: Todo
           <div className="mt-4">
             {isAddingTask ? (
             <div className="flex items-center gap-2 p-[2px]">
-              <div className="w-3.5 h-3.5 border border-black rounded-sm bg-white"></div>
+              <div className="w-3.5 h-3.5 border border-blue-500 rounded-sm bg-white"></div>
               <input
                 type="text"
                 value={newTaskTitle}
@@ -115,9 +115,9 @@ export function TodoList({ todos, onToggle, onDelete, onDeleteAll, onAdd }: Todo
           ) : (
             <button
               onClick={() => setIsAddingTask(true)}
-              className="flex items-center gap-2 text-sm text-gray-600 hover:text-black transition-colors"
+              className="flex items-center gap-2 text-sm text-blue-600 hover:text-blue-700 transition-colors bg-blue-50 hover:bg-blue-100 px-3 py-2 rounded-md"
             >
-              <span className="text-lg leading-none">+</span>
+              <span className="text-lg leading-none text-blue-600">+</span>
               <span>Add a task</span>
             </button>
           )}

--- a/src/components/TodoTabs.tsx
+++ b/src/components/TodoTabs.tsx
@@ -14,8 +14,8 @@ export function TodoTabs({ activeFilter, onFilterChange, activeCount, completedC
         onClick={() => onFilterChange('active')}
         className={`flex-1 py-2 px-4 text-sm font-medium transition-colors ${
           activeFilter === 'active'
-            ? 'text-black border-b-2 border-black'
-            : 'text-gray-500 hover:text-gray-700'
+            ? 'text-blue-600 border-b-2 border-blue-500'
+            : 'text-gray-500 hover:text-blue-600'
         }`}
         aria-current={activeFilter === 'active' ? 'page' : undefined}
       >
@@ -25,8 +25,8 @@ export function TodoTabs({ activeFilter, onFilterChange, activeCount, completedC
         onClick={() => onFilterChange('completed')}
         className={`flex-1 py-2 px-4 text-sm font-medium transition-colors ${
           activeFilter === 'completed'
-            ? 'text-black border-b-2 border-black'
-            : 'text-gray-500 hover:text-gray-700'
+            ? 'text-blue-600 border-b-2 border-blue-500'
+            : 'text-gray-500 hover:text-blue-600'
         }`}
         aria-current={activeFilter === 'completed' ? 'page' : undefined}
       >


### PR DESCRIPTION
## 概要
Todoアプリのボタンの色を黒から青に変更し、より現代的で視覚的に分かりやすいデザインにしました。

## 変更内容
- ✅ チェックボックスの枠線とチェックマークを青色(blue-500)に変更
- ✅ チェックボックスのホバー時の背景を薄い青色(blue-50)に変更
- ✅ 削除ボタンを赤色(red-500)に変更し、ホバー時により濃い赤色に
- ✅ "Add a task"ボタンを青色にし、背景色を追加してより目立つように
- ✅ タブのアクティブ状態とホバー時の色を青色に統一

## スクリーンショット
変更後、全体的に青を基調とした統一感のあるデザインになりました。

Closes #button_color

🤖 Generated with [Claude Code](https://claude.ai/code)