### PR TITLE
ボタンの色を紫色に変更

### DIFF
--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -12,12 +12,12 @@ export const TodoItem = memo(function TodoItem({ todo, onToggle, onDelete }: Tod
     <div className="group flex items-center gap-2 p-[2px] hover:bg-black/10 rounded transition-all duration-200">
       <button
         onClick={() => onToggle?.(todo.id)}
-        className="flex items-center justify-center w-3.5 h-3.5 border border-black rounded-sm bg-white hover:bg-gray-50 transition-colors"
+        className="flex items-center justify-center w-3.5 h-3.5 border border-purple-500 rounded-sm bg-white hover:bg-purple-50 transition-colors"
         aria-label={`${todo.title}${todo.completed ? 'を未完了にする' : 'を完了済みにする'}`}
       >
         {todo.completed && (
           <svg
-            className="w-3 h-3 text-black"
+            className="w-3 h-3 text-purple-500"
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 24 24"
             fill="none"
@@ -47,7 +47,7 @@ export const TodoItem = memo(function TodoItem({ todo, onToggle, onDelete }: Tod
         aria-label={`${todo.title}を削除`}
       >
         <svg
-          className="w-4 h-4 text-black"
+          className="w-4 h-4 text-purple-500 hover:text-purple-600"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"
           fill="none"

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -96,7 +96,7 @@ export function TodoList({ todos, onToggle, onDelete, onDeleteAll, onAdd }: Todo
           <div className="mt-4">
             {isAddingTask ? (
             <div className="flex items-center gap-2 p-[2px]">
-              <div className="w-3.5 h-3.5 border border-black rounded-sm bg-white"></div>
+              <div className="w-3.5 h-3.5 border border-purple-500 rounded-sm bg-white"></div>
               <input
                 type="text"
                 value={newTaskTitle}
@@ -115,9 +115,9 @@ export function TodoList({ todos, onToggle, onDelete, onDeleteAll, onAdd }: Todo
           ) : (
             <button
               onClick={() => setIsAddingTask(true)}
-              className="flex items-center gap-2 text-sm text-gray-600 hover:text-black transition-colors"
+              className="flex items-center gap-2 text-sm text-purple-600 hover:text-purple-700 transition-colors bg-purple-50 hover:bg-purple-100 px-3 py-2 rounded-md"
             >
-              <span className="text-lg leading-none">+</span>
+              <span className="text-lg leading-none text-purple-600">+</span>
               <span>Add a task</span>
             </button>
           )}

--- a/src/components/TodoTabs.tsx
+++ b/src/components/TodoTabs.tsx
@@ -14,8 +14,8 @@ export function TodoTabs({ activeFilter, onFilterChange, activeCount, completedC
         onClick={() => onFilterChange('active')}
         className={`flex-1 py-2 px-4 text-sm font-medium transition-colors ${
           activeFilter === 'active'
-            ? 'text-black border-b-2 border-black'
-            : 'text-gray-500 hover:text-gray-700'
+            ? 'text-purple-600 border-b-2 border-purple-500'
+            : 'text-gray-500 hover:text-purple-600'
         }`}
         aria-current={activeFilter === 'active' ? 'page' : undefined}
       >
@@ -25,8 +25,8 @@ export function TodoTabs({ activeFilter, onFilterChange, activeCount, completedC
         onClick={() => onFilterChange('completed')}
         className={`flex-1 py-2 px-4 text-sm font-medium transition-colors ${
           activeFilter === 'completed'
-            ? 'text-black border-b-2 border-black'
-            : 'text-gray-500 hover:text-gray-700'
+            ? 'text-purple-600 border-b-2 border-purple-500'
+            : 'text-gray-500 hover:text-purple-600'
         }`}
         aria-current={activeFilter === 'completed' ? 'page' : undefined}
       >


### PR DESCRIPTION
## 🚀 変更概要

### 📋 実装内容
- 9b0238b スタイル: TodoItem、TodoList、TodoTabsコンポーネントのボタンとテキストの色を紫に変更し、視覚的一貫性を向上

### 📁 ファイル変更
**変更**: src/components/TodoItem.tsx, src/components/TodoList.tsx, src/components/TodoTabs.tsx

## 🖼️ スクリーンショット

### Homepage
![Homepage](https://raw.githubusercontent.com/tatsuro13/claude-code-todo-app-on-vercel/main/screenshots/1753018378954-home.png)

## ✅ テスト項目
- [ ] 機能動作確認
- [ ] レスポンシブ確認
- [ ] 既存機能への影響なし