### PR TITLE
feat: change button colors from black to blue

### DIFF
--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -12,12 +12,12 @@ export const TodoItem = memo(function TodoItem({ todo, onToggle, onDelete }: Tod
     <div className="group flex items-center gap-2 p-[2px] hover:bg-black/10 rounded transition-all duration-200">
       <button
         onClick={() => onToggle?.(todo.id)}
-        className="flex items-center justify-center w-3.5 h-3.5 border border-black rounded-sm bg-white hover:bg-gray-50 transition-colors"
+        className="flex items-center justify-center w-3.5 h-3.5 border border-blue-600 rounded-sm bg-white hover:bg-blue-50 transition-colors"
         aria-label={`${todo.title}${todo.completed ? 'を未完了にする' : 'を完了済みにする'}`}
       >
         {todo.completed && (
           <svg
-            className="w-3 h-3 text-black"
+            className="w-3 h-3 text-blue-600"
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 24 24"
             fill="none"
@@ -47,7 +47,7 @@ export const TodoItem = memo(function TodoItem({ todo, onToggle, onDelete }: Tod
         aria-label={`${todo.title}を削除`}
       >
         <svg
-          className="w-4 h-4 text-black"
+          className="w-4 h-4 text-blue-600"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"
           fill="none"

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -62,7 +62,7 @@ export function TodoList({ todos, onToggle, onDelete, onDeleteAll, onAdd }: Todo
             className="w-5 h-5 flex items-center justify-center"
             aria-label="すべてのタスクを削除"
           >
-            <svg className="w-5 h-5 text-black" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <svg className="w-5 h-5 text-blue-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
               <polyline points="3 6 5 6 21 6"></polyline>
               <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
               <line x1="10" y1="11" x2="10" y2="17"></line>
@@ -115,7 +115,7 @@ export function TodoList({ todos, onToggle, onDelete, onDeleteAll, onAdd }: Todo
           ) : (
             <button
               onClick={() => setIsAddingTask(true)}
-              className="flex items-center gap-2 text-sm text-gray-600 hover:text-black transition-colors"
+              className="flex items-center gap-2 text-sm text-gray-600 hover:text-blue-600 transition-colors"
             >
               <span className="text-lg leading-none">+</span>
               <span>Add a task</span>

--- a/src/components/TodoTabs.tsx
+++ b/src/components/TodoTabs.tsx
@@ -14,7 +14,7 @@ export function TodoTabs({ activeFilter, onFilterChange, activeCount, completedC
         onClick={() => onFilterChange('active')}
         className={`flex-1 py-2 px-4 text-sm font-medium transition-colors ${
           activeFilter === 'active'
-            ? 'text-black border-b-2 border-black'
+            ? 'text-blue-600 border-b-2 border-blue-600'
             : 'text-gray-500 hover:text-gray-700'
         }`}
         aria-current={activeFilter === 'active' ? 'page' : undefined}
@@ -25,7 +25,7 @@ export function TodoTabs({ activeFilter, onFilterChange, activeCount, completedC
         onClick={() => onFilterChange('completed')}
         className={`flex-1 py-2 px-4 text-sm font-medium transition-colors ${
           activeFilter === 'completed'
-            ? 'text-black border-b-2 border-black'
+            ? 'text-blue-600 border-b-2 border-blue-600'
             : 'text-gray-500 hover:text-gray-700'
         }`}
         aria-current={activeFilter === 'completed' ? 'page' : undefined}


### PR DESCRIPTION
This PR updates button colors to use blue-600 across TodoItem, TodoList, and TodoTabs components for better visual consistency.

Changes:
- TodoItem.tsx: Updated checkbox border, hover state, checkmark icon, and delete button colors
- TodoList.tsx: Updated delete all button icon and add task hover state colors
- TodoTabs.tsx: Updated active tab text and border colors

Closes #22

Generated with [Claude Code](https://claude.ai/code)